### PR TITLE
Fix MOFH Callback: Client Removed Subdomain

### DIFF
--- a/pages/initial-setup/callbacks.mdx
+++ b/pages/initial-setup/callbacks.mdx
@@ -31,7 +31,7 @@ In this example, the URL `https://example.com/callback` is used.
 Then, click on "Update Settings" and everything should be set up!
 
 ## Hosting Account Callbacks
-
+CLIENT
 The following hosting account callbacks are available:
 
 ### Account Activation
@@ -133,7 +133,7 @@ comments: <vpanel_username>
    
     Parked Domain Removed: `CLIENTPARKREM`
 
-    Subdomain Removed: `CLIENTSUBREM`
+    Subdomain Removed: `CLIENTSUBDEL`
 
     Addon Domain Removed: `CLIENTDOMREM`
 </Callout>

--- a/pages/initial-setup/callbacks.mdx
+++ b/pages/initial-setup/callbacks.mdx
@@ -31,7 +31,7 @@ In this example, the URL `https://example.com/callback` is used.
 Then, click on "Update Settings" and everything should be set up!
 
 ## Hosting Account Callbacks
-CLIENT
+
 The following hosting account callbacks are available:
 
 ### Account Activation


### PR DESCRIPTION
For some unknown reason, the subdomain callback for subdomains is 'SUBDEL' instead of 'SUBREM' like the others. Adjusted the docs to show this.